### PR TITLE
Fix load block and ensure proper loop handling

### DIFF
--- a/toggle-gpu2r1.sh
+++ b/toggle-gpu2r1.sh
@@ -161,7 +161,6 @@ case "$1" in
   load)
     log "► Reverting VFIO → NVIDIA (for host/container use)"
     # 1) Unbind from VFIO
-    for m in "${VFIO_DRIVERS_UNLOAD[@]}"; do
     unbind_device "$PCI_VGA"   vfio-pci
     unbind_device "$PCI_AUDIO" vfio-pci
 
@@ -181,7 +180,14 @@ case "$1" in
     ;;
 
   *)
+    cat <<EOF
+Usage: $0 {unload|load}
 
+  unload   → unload NVIDIA, bind GPU to vfio-pci (for VM passthrough)
+  load     → unload vfio-pci, load NVIDIA modules (for host/containers)
+EOF
+    exit 1
+    ;;
 esac
 
 cleanup() {
@@ -217,14 +223,4 @@ while read -r consoleNumber; do
   fi
 done < "$input"
 }
-
-log "End of Teardown!"
-    cat <<EOF
-Usage: $0 {unload|load}
-
-  unload   → unload NVIDIA, bind GPU to vfio-pci (for VM passthrough)
-  load     → unload vfio-pci, load NVIDIA modules (for host/containers)
-EOF
-    exit 1
-    ;;
 


### PR DESCRIPTION
## Summary
- remove unused VFIO driver loop in `load` path and unbind devices directly
- consolidate usage output into default case for proper case statement termination

## Testing
- `shellcheck toggle-gpu2r1.sh`


------
https://chatgpt.com/codex/tasks/task_e_688eaeb961d883298065fda0bbca6f72